### PR TITLE
Style header h1 text white in header-centered-dark theme

### DIFF
--- a/css/theme.scss
+++ b/css/theme.scss
@@ -23,6 +23,10 @@
 
 /* body_classes: header-centered-dark */
 
+.header-centered-dark header h1 {
+  color: white;
+}
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
## Summary
Added styling to make the h1 heading text white in the header-centered-dark theme variant.

## Changes
- Added CSS rule for `.header-centered-dark header h1` to set text color to white

## Details
This change ensures that h1 headings within the header element are properly styled with white text when the header-centered-dark body class is applied, improving contrast and visual consistency for this theme variant.

https://claude.ai/code/session_013u2XMhZxCA454Twyp2z1AG