### PR TITLE
Migrate all pages to design-system-base layout with block structure

### DIFF
--- a/categories/for-sale.md
+++ b/categories/for-sale.md
@@ -9,7 +9,7 @@ meta_title: Parts and Equipment for Sale - Essex Inflatables
 redirect_from:
   - /Equipement For Sale.html
 featured: true
-layout: design-system-base.md
+layout: design-system-base.html
 blocks:
   - type: hero
     title: Parts & Equipment

--- a/categories/for-sale.md
+++ b/categories/for-sale.md
@@ -9,30 +9,36 @@ meta_title: Parts and Equipment for Sale - Essex Inflatables
 redirect_from:
   - /Equipement For Sale.html
 featured: true
+layout: design-system-base.md
+blocks:
+  - type: hero
+    title: Parts & Equipment
+  - type: markdown
+    content: |
+      ## Parts and Equipment for Inflatable Operators
+
+      We supply essential parts and equipment for operators of inflatable play equipment. Our stock includes both new and reconditioned items, with availability varying based on current demand and supply.
+
+      ### Currently Available
+
+      We maintain stocks of the following items, though availability varies:
+
+      - Stakes for securing inflatables (PIPA standard)
+      - Fans and blowers (new and reconditioned)
+      - Replacement parts and accessories
+      - Second-hand equipment (when available)
+
+      ### Pricing and Availability
+
+      Prices fluctuate based on material costs and market conditions. Stakes pricing depends on current steel costs. Fan and blower prices vary by specification and condition. We provide current quotes on request.
+
+      Second-hand equipment becomes available periodically through our industry connections. Quality used inflatables, tested and certified equipment, and bulk lots occasionally become available.
+
+      ### How to Order
+
+      Contact us for current stock levels and pricing:
+      - Phone: 01268 569302
+      - Email: enquiries@essexinflatables.co.uk
+
+      We prefer to provide written quotes via email to ensure accurate pricing and clear communication about specifications and availability.
 ---
-## Parts and Equipment for Inflatable Operators
-
-We supply essential parts and equipment for operators of inflatable play equipment. Our stock includes both new and reconditioned items, with availability varying based on current demand and supply.
-
-### Currently Available
-
-We maintain stocks of the following items, though availability varies:
-
-- Stakes for securing inflatables (PIPA standard)
-- Fans and blowers (new and reconditioned)
-- Replacement parts and accessories
-- Second-hand equipment (when available)
-
-### Pricing and Availability
-
-Prices fluctuate based on material costs and market conditions. Stakes pricing depends on current steel costs. Fan and blower prices vary by specification and condition. We provide current quotes on request.
-
-Second-hand equipment becomes available periodically through our industry connections. Quality used inflatables, tested and certified equipment, and bulk lots occasionally become available.
-
-### How to Order
-
-Contact us for current stock levels and pricing:
-- Phone: 01268 569302
-- Email: enquiries@essexinflatables.co.uk
-
-We prefer to provide written quotes via email to ensure accurate pricing and clear communication about specifications and availability.

--- a/categories/repairs.md
+++ b/categories/repairs.md
@@ -7,35 +7,41 @@ meta_description: Expert repair services for all types of inflatable damage.
   since 1994.
 meta_title: Professional Inflatable Repair Services - Essex Inflatables
 featured: true
+layout: design-system-base.md
+blocks:
+  - type: hero
+    title: Professional Repairs
+  - type: markdown
+    content: |
+      ## Professional Inflatable Repair Services
+
+      Our dedicated repair facility has been serving inflatable operators since 1994. We handle all types of repairs from minor patches to complete structural rebuilds, using professional-grade equipment and materials.
+
+      ### Types of Repairs
+
+      We specialise in:
+      - Bed and panel stitching
+      - Complete panel replacements
+      - Rips and tears of all sizes
+      - Anchor point repairs and reinforcement
+      - Internal structural repairs
+      - Zip replacements
+      - Diaphragm repairs
+      - Blower and fan maintenance
+
+      ### Our Facility
+
+      All repairs are completed at our professional workshop in the Hullbridge area. Our facility features:
+      - Air-cooled twin needle sewing machines
+      - Comprehensive stock of quality PVC materials
+      - Professional-grade threads and adhesives
+      - Controlled environment for consistent quality
+
+      ### Getting a Quote
+
+      Send us photographs of the damage along with details about your equipment. We provide detailed quotes based on the specific repair requirements. Our £30 pre-examination service includes thorough assessment and written quote.
+
+      Contact us:
+      - Phone: 01268 569302
+      - Email: enquiries@essexinflatables.co.uk
 ---
-## Professional Inflatable Repair Services
-
-Our dedicated repair facility has been serving inflatable operators since 1994. We handle all types of repairs from minor patches to complete structural rebuilds, using professional-grade equipment and materials.
-
-### Types of Repairs
-
-We specialise in:
-- Bed and panel stitching
-- Complete panel replacements
-- Rips and tears of all sizes
-- Anchor point repairs and reinforcement
-- Internal structural repairs
-- Zip replacements
-- Diaphragm repairs
-- Blower and fan maintenance
-
-### Our Facility
-
-All repairs are completed at our professional workshop in the Hullbridge area. Our facility features:
-- Air-cooled twin needle sewing machines
-- Comprehensive stock of quality PVC materials
-- Professional-grade threads and adhesives
-- Controlled environment for consistent quality
-
-### Getting a Quote
-
-Send us photographs of the damage along with details about your equipment. We provide detailed quotes based on the specific repair requirements. Our £30 pre-examination service includes thorough assessment and written quote.
-
-Contact us:
-- Phone: 01268 569302
-- Email: enquiries@essexinflatables.co.uk

--- a/categories/repairs.md
+++ b/categories/repairs.md
@@ -7,7 +7,7 @@ meta_description: Expert repair services for all types of inflatable damage.
   since 1994.
 meta_title: Professional Inflatable Repair Services - Essex Inflatables
 featured: true
-layout: design-system-base.md
+layout: design-system-base.html
 blocks:
   - type: hero
     title: Professional Repairs

--- a/categories/tests.md
+++ b/categories/tests.md
@@ -7,7 +7,7 @@ meta_description: Certified PIPA inspection body since 2004. Annual safety
   Southeast England.
 meta_title: PIPA Testing and Safety Inspections - Essex Inflatables
 featured: true
-layout: design-system-base.md
+layout: design-system-base.html
 blocks:
   - type: hero
     title: Safety Inspections

--- a/categories/tests.md
+++ b/categories/tests.md
@@ -7,39 +7,45 @@ meta_description: Certified PIPA inspection body since 2004. Annual safety
   Southeast England.
 meta_title: PIPA Testing and Safety Inspections - Essex Inflatables
 featured: true
+layout: design-system-base.md
+blocks:
+  - type: hero
+    title: Safety Inspections
+  - type: markdown
+    content: |
+      ## PIPA Testing and Safety Inspections
+
+      As a certified PIPA Inspection Body since 2004, we provide comprehensive annual safety inspections for all types of inflatable play equipment. Our inspections ensure your equipment meets HSE health and safety requirements.
+
+      ### What We Inspect
+
+      PIPA testing covers:
+      - Bouncy castles and themed units
+      - Slides and combination units
+      - Assault courses and obstacles
+      - Disco domes and party inflatables
+      - Multi-play equipment
+      - All continuous flow land inflatables
+
+      We also inspect equipment outside PIPA's remit, including pole joust, pool inflatables, gladiator duels, and other specialised units.
+
+      ### Inspection Standards
+
+      Our certified inspectors follow:
+      - BS EN 14960 EU safety standard
+      - HSE health and safety guidelines
+      - PIPA scheme requirements
+      - Industry best practices
+
+      ### Service Coverage
+
+      We travel throughout Essex, London, Kent, Hertfordshire, Surrey, and the Southeast for inspections. We visit operator premises, council facilities, schools, and storage locations.
+
+      ### Booking Inspections
+
+      Schedule your annual inspection before certificate expiry:
+      - Phone: 01268 569302
+      - Email: enquiries@essexinflatables.co.uk
+
+      We provide written quotes and work around your operational schedule.
 ---
-## PIPA Testing and Safety Inspections
-
-As a certified PIPA Inspection Body since 2004, we provide comprehensive annual safety inspections for all types of inflatable play equipment. Our inspections ensure your equipment meets HSE health and safety requirements.
-
-### What We Inspect
-
-PIPA testing covers:
-- Bouncy castles and themed units
-- Slides and combination units
-- Assault courses and obstacles
-- Disco domes and party inflatables
-- Multi-play equipment
-- All continuous flow land inflatables
-
-We also inspect equipment outside PIPA's remit, including pole joust, pool inflatables, gladiator duels, and other specialised units.
-
-### Inspection Standards
-
-Our certified inspectors follow:
-- BS EN 14960 EU safety standard
-- HSE health and safety guidelines
-- PIPA scheme requirements
-- Industry best practices
-
-### Service Coverage
-
-We travel throughout Essex, London, Kent, Hertfordshire, Surrey, and the Southeast for inspections. We visit operator premises, council facilities, schools, and storage locations.
-
-### Booking Inspections
-
-Schedule your annual inspection before certificate expiry:
-- Phone: 01268 569302
-- Email: enquiries@essexinflatables.co.uk
-
-We provide written quotes and work around your operational schedule.

--- a/news/1980-01-01-second.md
+++ b/news/1980-01-01-second.md
@@ -5,7 +5,7 @@ date: 2026-02-24
 meta_description: Essex Inflatable Repair service, Bouncy castle repairs, Essex Inflatables
 meta_title: First Post
 subtitle: Essex Inflatables New Website
-layout: design-system-base.md
+layout: design-system-base.html
 blocks:
   - type: hero
     title: New Improved Essex Inflatables Website!

--- a/news/1980-01-01-second.md
+++ b/news/1980-01-01-second.md
@@ -5,50 +5,57 @@ date: 2026-02-24
 meta_description: Essex Inflatable Repair service, Bouncy castle repairs, Essex Inflatables
 meta_title: First Post
 subtitle: Essex Inflatables New Website
+layout: design-system-base.md
+blocks:
+  - type: hero
+    title: New Improved Essex Inflatables Website!
+    lead: Essex Inflatables New Website
+  - type: markdown
+    content: |
+      # Welcome to Our Brand-New Website – Essex Inflatables Repair Services Just Got Even Better!
+
+      We’re thrilled to unveil our brand-new website at www.essexinflatables.co.uk
+
+      After months of hard work, we now have a faster, cleaner, and more user-friendly home online – designed specifically to help bouncy castle & inflatable owners across Essex and the South East get fast, reliable repairs, annual PiPA testing, and expert advice whenever you need it.
+
+      ### Why We Built a New Site
+      Our old site had served us well, but as Essex’s go-to inflatable repair specialists, we wanted a platform that reflects the quality, speed, and care we put into every job. Here’s what’s new and improved:
+
+      - **Mobile-Friendly Design** – Book repairs or request a quote easily from your phone at the park, party, or in the van.
+      - **Clear Repair Services Overview** – Full details on what we fix (seams, tears, zips, bounce mats, diaframes, and more).
+      - **PiPA Testing Information** – Everything you need to know about annual safety inspections, certificates, and legal requirements.
+      - **Easy Quote Form** – Email a photos of damage and get a quick, no-obligation estimate.
+      - **Before & After Gallery** – Real examples of inflatable repairs we’ve completed across Essex.
+      - **Fast Contact Options** – WhatsApp, phone, email, and live chat all in one place.
+
+      ### Who We Are & Why Choose Us
+      We’re a family-run business with over 20 years of experience in the inflatable industry. We don’t just patch things up – we restore inflatables to safe, like-new condition using high-quality materials and professional techniques.
+
+      Whether you run a hire company, own a single castle for home use, or manage a soft play centre, we treat every job with the same care. All repairs come with our standard guarantees, and we’re fully insured and PiPA-accredited.
+
+      ### Recent Repair Highlights
+      - Fixed multiple large seam splits on 15ft bouncy castles – back in service within 48 hours
+      - Replaced worn slide mats/ slip sheets and repacment of slide stairs
+      - Full PiPA inspections & certificates issued for over 200 inflatables last year
+
+      ### What’s Next?
+      We’re already working on more features:
+      - Online booking calendar for drop-off & collection
+      - Live chat support
+      - Helpful guides & videos (e.g., “How to Spot Wear Before It Becomes a Tear”)
+
+      ### Got an Inflatable That Needs Attention?
+      Whether it’s a small tear, a major seam split, or you’re due a PiPA test – get in touch today.
+
+      📞 Call/WhatsApp: 07976 979727
+      📧 Email: clive@essexinflatables.co.uk  
+
+      We usually respond within 3 hours during business hours and aim to give you a fast, honest assessment.
+
+      Thanks for being part of the Essex Inflatables family – we’re excited to keep your inflatables bouncing safely for years to come!
+
+      Best regards,  
+      The Essex Inflatables Team  
+      Essex’s Trusted Bouncy Castle & Inflatable Repair Specialists  
+      essexinflatables.co.uk
 ---
-# Welcome to Our Brand-New Website – Essex Inflatables Repair Services Just Got Even Better!
-
-We’re thrilled to unveil our brand-new website at www.essexinflatables.co.uk
-
-After months of hard work, we now have a faster, cleaner, and more user-friendly home online – designed specifically to help bouncy castle & inflatable owners across Essex and the South East get fast, reliable repairs, annual PiPA testing, and expert advice whenever you need it.
-
-### Why We Built a New Site
-Our old site had served us well, but as Essex’s go-to inflatable repair specialists, we wanted a platform that reflects the quality, speed, and care we put into every job. Here’s what’s new and improved:
-
-- **Mobile-Friendly Design** – Book repairs or request a quote easily from your phone at the park, party, or in the van.
-- **Clear Repair Services Overview** – Full details on what we fix (seams, tears, zips, bounce mats, diaframes, and more).
-- **PiPA Testing Information** – Everything you need to know about annual safety inspections, certificates, and legal requirements.
-- **Easy Quote Form** – Email a photos of damage and get a quick, no-obligation estimate.
-- **Before & After Gallery** – Real examples of inflatable repairs we’ve completed across Essex.
-- **Fast Contact Options** – WhatsApp, phone, email, and live chat all in one place.
-
-### Who We Are & Why Choose Us
-We’re a family-run business with over 20 years of experience in the inflatable industry. We don’t just patch things up – we restore inflatables to safe, like-new condition using high-quality materials and professional techniques.
-
-Whether you run a hire company, own a single castle for home use, or manage a soft play centre, we treat every job with the same care. All repairs come with our standard guarantees, and we’re fully insured and PiPA-accredited.
-
-### Recent Repair Highlights
-- Fixed multiple large seam splits on 15ft bouncy castles – back in service within 48 hours
-- Replaced worn slide mats/ slip sheets and repacment of slide stairs
-- Full PiPA inspections & certificates issued for over 200 inflatables last year
-
-### What’s Next?
-We’re already working on more features:
-- Online booking calendar for drop-off & collection
-- Live chat support
-- Helpful guides & videos (e.g., “How to Spot Wear Before It Becomes a Tear”)
-
-### Got an Inflatable That Needs Attention?
-Whether it’s a small tear, a major seam split, or you’re due a PiPA test – get in touch today.
-
-📞 Call/WhatsApp: 07976 979727
-📧 Email: clive@essexinflatables.co.uk  
-
-We usually respond within 3 hours during business hours and aim to give you a fast, honest assessment.
-
-Thanks for being part of the Essex Inflatables family – we’re excited to keep your inflatables bouncing safely for years to come!
-
-Best regards,  
-The Essex Inflatables Team  
-Essex’s Trusted Bouncy Castle & Inflatable Repair Specialists  
-essexinflatables.co.uk

--- a/pages/contact.md
+++ b/pages/contact.md
@@ -8,7 +8,7 @@ meta_title: Contact Essex Inflatables - Testing & Repair Services
 eleventyNavigation:
   key: Contact
   order: 6
-layout: design-system-base.md
+layout: design-system-base.html
 permalink: /contact/
 redirect_from:
   - /Contact.html

--- a/pages/contact.md
+++ b/pages/contact.md
@@ -8,51 +8,56 @@ meta_title: Contact Essex Inflatables - Testing & Repair Services
 eleventyNavigation:
   key: Contact
   order: 6
-layout: contact.html
+layout: design-system-base.md
 permalink: /contact/
 redirect_from:
   - /Contact.html
+blocks:
+  - type: hero
+    title: Contact Us
+  - type: markdown
+    content: |
+      ## Get in Touch
+
+      We are available to discuss your inflatable equipment repair and inspection needs. Contact us by phone or email for quotes, bookings, and enquiries. We prefer to provide written quotes via email to ensure clear communication and accurate pricing.
+
+      ### Contact Details
+
+      **Phone:** [01268 569302]
+      **Mobile:** [07976 979727]
+      Please note our mobile number will be changing soon. We will update this information when the new number is active.
+
+      **Email:** [enquiries@essexinflatables.co.uk]
+      For quotes, please include photographs of any damage and details about your equipment.
+
+      ### Office Address
+
+      Ellis House
+      Felsted Road
+      Benfleet
+      Essex
+      SS7 1BT
+
+      Please note that repairs are completed at our workshop facility in the Hullbridge area (SS5 POSTCODE). The exact location will be provided when you arrange to deliver equipment for repair.
+
+      ### Preferred Contact Methods
+
+      We welcome enquiries by both phone and email. For quote requests, email is preferred as it allows us to provide detailed written quotes and maintain clear records. When contacting us about repairs, please provide:
+
+      - Type and size of inflatable
+      - Description of damage or issues
+      - Photographs showing the affected areas
+      - Your location and any access requirements for inspections
+
+      ### Business Hours
+
+      Monday to Friday 9am - 5pm
+
+      For emergency repairs outside standard hours, additional call-out charges apply. Please contact us to discuss urgent requirements and pricing.
+
+      ### Service Coverage
+
+      We provide PIPA inspection services throughout Essex, London, Kent, Hertfordshire, Surrey, and the Southeast region. For repairs, equipment must be delivered to our Hullbridge facility.
+
+      Use the form below to send us an enquiry and we will respond as soon as possible.
 ---
-## Get in Touch
-
-We are available to discuss your inflatable equipment repair and inspection needs. Contact us by phone or email for quotes, bookings, and enquiries. We prefer to provide written quotes via email to ensure clear communication and accurate pricing.
-
-### Contact Details
-
-**Phone:** [01268 569302]
-**Mobile:** [07976 979727]
-Please note our mobile number will be changing soon. We will update this information when the new number is active.
-
-**Email:** [enquiries@essexinflatables.co.uk]
-For quotes, please include photographs of any damage and details about your equipment.
-
-### Office Address
-
-Ellis House
-Felsted Road
-Benfleet
-Essex
-SS7 1BT
-
-Please note that repairs are completed at our workshop facility in the Hullbridge area (SS5 POSTCODE). The exact location will be provided when you arrange to deliver equipment for repair.
-
-### Preferred Contact Methods
-
-We welcome enquiries by both phone and email. For quote requests, email is preferred as it allows us to provide detailed written quotes and maintain clear records. When contacting us about repairs, please provide:
-
-- Type and size of inflatable
-- Description of damage or issues
-- Photographs showing the affected areas
-- Your location and any access requirements for inspections
-
-### Business Hours
-
-Monday to Friday 9am - 5pm
-
-For emergency repairs outside standard hours, additional call-out charges apply. Please contact us to discuss urgent requirements and pricing.
-
-### Service Coverage
-
-We provide PIPA inspection services throughout Essex, London, Kent, Hertfordshire, Surrey, and the Southeast region. For repairs, equipment must be delivered to our Hullbridge facility.
-
-Use the form below to send us an enquiry and we will respond as soon as possible.

--- a/pages/faq.md
+++ b/pages/faq.md
@@ -9,7 +9,7 @@ subtitle: Common Questions About Our Services
 eleventyNavigation:
   key: FAQ
   order: 5
-layout: design-system-base.md
+layout: design-system-base.html
 permalink: /faq/
 blocks:
   - type: hero

--- a/pages/faq.md
+++ b/pages/faq.md
@@ -9,67 +9,73 @@ subtitle: Common Questions About Our Services
 eleventyNavigation:
   key: FAQ
   order: 5
-layout: base.html
+layout: design-system-base.md
 permalink: /faq/
+blocks:
+  - type: hero
+    title: Frequently Asked Questions
+    lead: Common Questions About Our Services
+  - type: markdown
+    content: |
+      ## Frequently Asked Questions
+
+      ### How much does a repair cost?
+
+      Repair costs vary depending on several factors including the size of your inflatable, the extent of damage, and the complexity of the repair required. We provide quotes on a case-by-case basis after assessing the specific requirements. To get an accurate quote, we ask that you send photographs of the damage along with information about the inflatable's size and manufacturer. For a detailed assessment, we offer a pre-examination service for £30, where we thoroughly inspect your equipment and provide a comprehensive written quote.
+
+      Different types of repairs carry different costs. Simple patches might be relatively inexpensive, whilst panel replacements or internal structural repairs require more time and materials. Some manufacturer designs are more accessible than others, which can affect labour time. We always aim to provide transparent, fair pricing based on the actual work required.
+
+      ### How often do I need my equipment PIPA tested?
+
+      PIPA testing is required annually for all commercial inflatable play equipment. Your PIPA certificate is valid for one year from the date of inspection, and you should arrange your next inspection before the certificate expires to maintain continuous compliance. We recommend booking your annual inspection well in advance of the expiry date to ensure availability and avoid any gaps in certification.
+
+      Some operators choose to have inspections done during quieter winter months when their equipment is not in regular use. This timing allows for any necessary repairs to be completed before the busy season begins. Regular annual inspections help identify developing issues early, potentially saving money on major repairs later.
+
+      ### What is included in a PIPA inspection?
+
+      A PIPA inspection is a comprehensive safety assessment of your inflatable equipment. Our certified inspector examines all aspects of the inflatable including structural integrity, seam strength, material condition, and anchor points. We check for signs of wear, damage, or modifications that might affect safety. The inspection follows strict protocols set out in the BS EN 14960 standard.
+
+      Following the inspection, you receive a PIPA certificate if your equipment passes, along with a detailed inspection report. If any issues are identified, we provide information about required repairs or maintenance. We can also provide quotes for any necessary repair work, which can be completed at our facility. The inspection includes testing of the inflatable itself, though electrical equipment like blowers may require separate PAT testing.
+
+      ### Do you travel outside of Essex?
+
+      Yes, we serve a wide area beyond Essex. Our service coverage includes London, Kent, Hertfordshire, Surrey, and the broader Southeast region. For PIPA inspections, we travel to operator locations, council facilities, schools, and storage sites throughout these areas. Travel charges apply based on distance and time requirements, with quotes provided when you book our services.
+
+      For repairs, equipment must be brought to our facility in the Hullbridge area, as we do not currently offer mobile on-site repairs. This ensures we have access to all necessary equipment and materials to complete repairs to the highest standard. We can discuss collection options for larger items or multiple pieces of equipment.
+
+      ### Can you repair my inflatable on-site?
+
+      Currently, all repairs must be completed at our dedicated facility in Hullbridge. We do not offer mobile on-site repairs at this time. This in-house approach ensures we have access to our professional equipment, including air-cooled twin needle sewing machines, comprehensive material stocks, and proper working conditions necessary for quality repairs.
+
+      We understand this means operators need to transport their equipment to us, but this approach ensures the best possible repair quality. Our controlled workshop environment allows us to complete complex repairs that would be impossible or impractical to attempt on-site. Mobile repair services are something we are considering for future years.
+
+      ### What if I need an emergency repair?
+
+      We offer emergency call-out services for urgent repair situations. However, even for emergency repairs, equipment must be brought to our facility. Emergency services help prioritise urgent repairs to minimise your downtime during peak operating periods. Call-out charges for emergency services vary depending on timing and location.
+
+      Standard business hours emergency calls are charged at our regular call-out rate. Out-of-hours emergency services, including evenings and weekends, incur additional charges. When you contact us for emergency repair, we provide clear pricing information and estimated turnaround times based on the urgency and complexity of the repair.
+
+      ### Do you sell parts and equipment?
+
+      We maintain stocks of essential spare parts and equipment for operators. This includes replacement fans and blowers, both new and reconditioned units. We stock repair materials including patches, glue, and thread for operators who handle minor repairs themselves. Stakes for securing inflatables are available, with pricing dependent on current steel costs.
+
+      Second-hand equipment becomes available occasionally through our connections with Ellis Leisure (www.ellisleisure.co.uk) and other operators. When quality used equipment is available, we can facilitate sales between operators. We do not manufacture new inflatables ourselves, though this is something we are exploring for the future along with import and export opportunities.
+
+      ### How do I book a PIPA inspection?
+
+      Contact us by phone on 01268 569302 or email enquiries@essexinflatables.co.uk with details of your equipment and preferred inspection dates. We need to know the number and types of inflatables requiring inspection, your location, and any specific access requirements. We recommend booking well in advance of your certificate expiry date.
+
+      We provide written quotes via email for all inspection services, which is our preferred method for maintaining clear records. Once you approve the quote, we schedule your inspection at a mutually convenient time. For venues with specific access requirements, such as schools that need after-hours inspection, we arrange appropriate timing.
+
+      ### What areas do you cover for different services?
+
+      For PIPA inspections, we travel throughout Essex, London, Kent, Hertfordshire, Surrey, and the Southeast region. We visit operator premises, council facilities, schools, and storage locations. Travel charges apply based on distance and timing requirements.
+
+      For repairs, equipment must come to our Hullbridge facility. We serve the same geographical area, but operators are responsible for delivering equipment to us or arranging collection. This ensures all repairs benefit from our professional workshop facilities and equipment.
+
+      ### How long do repairs typically take?
+
+      Repair timeframes vary depending on the complexity of work required and our current workload. Simple repairs like small patches might be completed within a day or two, whilst complex structural repairs or multiple panel replacements may take longer. We provide estimated timeframes when quoting for repairs.
+
+      During busy periods, particularly early in the season, turnaround times may be extended. We keep operators informed about progress and can provide updates on request. For emergency repairs, we prioritise work to minimise downtime, though this may incur additional charges.
 ---
-## Frequently Asked Questions
-
-### How much does a repair cost?
-
-Repair costs vary depending on several factors including the size of your inflatable, the extent of damage, and the complexity of the repair required. We provide quotes on a case-by-case basis after assessing the specific requirements. To get an accurate quote, we ask that you send photographs of the damage along with information about the inflatable's size and manufacturer. For a detailed assessment, we offer a pre-examination service for £30, where we thoroughly inspect your equipment and provide a comprehensive written quote.
-
-Different types of repairs carry different costs. Simple patches might be relatively inexpensive, whilst panel replacements or internal structural repairs require more time and materials. Some manufacturer designs are more accessible than others, which can affect labour time. We always aim to provide transparent, fair pricing based on the actual work required.
-
-### How often do I need my equipment PIPA tested?
-
-PIPA testing is required annually for all commercial inflatable play equipment. Your PIPA certificate is valid for one year from the date of inspection, and you should arrange your next inspection before the certificate expires to maintain continuous compliance. We recommend booking your annual inspection well in advance of the expiry date to ensure availability and avoid any gaps in certification.
-
-Some operators choose to have inspections done during quieter winter months when their equipment is not in regular use. This timing allows for any necessary repairs to be completed before the busy season begins. Regular annual inspections help identify developing issues early, potentially saving money on major repairs later.
-
-### What is included in a PIPA inspection?
-
-A PIPA inspection is a comprehensive safety assessment of your inflatable equipment. Our certified inspector examines all aspects of the inflatable including structural integrity, seam strength, material condition, and anchor points. We check for signs of wear, damage, or modifications that might affect safety. The inspection follows strict protocols set out in the BS EN 14960 standard.
-
-Following the inspection, you receive a PIPA certificate if your equipment passes, along with a detailed inspection report. If any issues are identified, we provide information about required repairs or maintenance. We can also provide quotes for any necessary repair work, which can be completed at our facility. The inspection includes testing of the inflatable itself, though electrical equipment like blowers may require separate PAT testing.
-
-### Do you travel outside of Essex?
-
-Yes, we serve a wide area beyond Essex. Our service coverage includes London, Kent, Hertfordshire, Surrey, and the broader Southeast region. For PIPA inspections, we travel to operator locations, council facilities, schools, and storage sites throughout these areas. Travel charges apply based on distance and time requirements, with quotes provided when you book our services.
-
-For repairs, equipment must be brought to our facility in the Hullbridge area, as we do not currently offer mobile on-site repairs. This ensures we have access to all necessary equipment and materials to complete repairs to the highest standard. We can discuss collection options for larger items or multiple pieces of equipment.
-
-### Can you repair my inflatable on-site?
-
-Currently, all repairs must be completed at our dedicated facility in Hullbridge. We do not offer mobile on-site repairs at this time. This in-house approach ensures we have access to our professional equipment, including air-cooled twin needle sewing machines, comprehensive material stocks, and proper working conditions necessary for quality repairs.
-
-We understand this means operators need to transport their equipment to us, but this approach ensures the best possible repair quality. Our controlled workshop environment allows us to complete complex repairs that would be impossible or impractical to attempt on-site. Mobile repair services are something we are considering for future years.
-
-### What if I need an emergency repair?
-
-We offer emergency call-out services for urgent repair situations. However, even for emergency repairs, equipment must be brought to our facility. Emergency services help prioritise urgent repairs to minimise your downtime during peak operating periods. Call-out charges for emergency services vary depending on timing and location.
-
-Standard business hours emergency calls are charged at our regular call-out rate. Out-of-hours emergency services, including evenings and weekends, incur additional charges. When you contact us for emergency repair, we provide clear pricing information and estimated turnaround times based on the urgency and complexity of the repair.
-
-### Do you sell parts and equipment?
-
-We maintain stocks of essential spare parts and equipment for operators. This includes replacement fans and blowers, both new and reconditioned units. We stock repair materials including patches, glue, and thread for operators who handle minor repairs themselves. Stakes for securing inflatables are available, with pricing dependent on current steel costs.
-
-Second-hand equipment becomes available occasionally through our connections with Ellis Leisure (www.ellisleisure.co.uk) and other operators. When quality used equipment is available, we can facilitate sales between operators. We do not manufacture new inflatables ourselves, though this is something we are exploring for the future along with import and export opportunities.
-
-### How do I book a PIPA inspection?
-
-Contact us by phone on 01268 569302 or email enquiries@essexinflatables.co.uk with details of your equipment and preferred inspection dates. We need to know the number and types of inflatables requiring inspection, your location, and any specific access requirements. We recommend booking well in advance of your certificate expiry date.
-
-We provide written quotes via email for all inspection services, which is our preferred method for maintaining clear records. Once you approve the quote, we schedule your inspection at a mutually convenient time. For venues with specific access requirements, such as schools that need after-hours inspection, we arrange appropriate timing.
-
-### What areas do you cover for different services?
-
-For PIPA inspections, we travel throughout Essex, London, Kent, Hertfordshire, Surrey, and the Southeast region. We visit operator premises, council facilities, schools, and storage locations. Travel charges apply based on distance and timing requirements.
-
-For repairs, equipment must come to our Hullbridge facility. We serve the same geographical area, but operators are responsible for delivering equipment to us or arranging collection. This ensures all repairs benefit from our professional workshop facilities and equipment.
-
-### How long do repairs typically take?
-
-Repair timeframes vary depending on the complexity of work required and our current workload. Simple repairs like small patches might be completed within a day or two, whilst complex structural repairs or multiple panel replacements may take longer. We provide estimated timeframes when quoting for repairs.
-
-During busy periods, particularly early in the season, turnaround times may be extended. We keep operators informed about progress and can provide updates on request. For emergency repairs, we prioritise work to minimise downtime, though this may incur additional charges.

--- a/pages/home.md
+++ b/pages/home.md
@@ -8,25 +8,30 @@ meta_title: Essex Inflatables - Testing & Repair Facility for Inflatable Equipme
 eleventyNavigation:
   key: Home
   order: 0
-layout: home.html
+layout: design-system-base.md
 permalink: /
+blocks:
+  - type: hero
+    title: Essex Inflatables
+  - type: markdown
+    content: |
+      ![Essex Inflatables](/images/essex-banner.jpg)
+
+      ## Professional Testing and Repair Facility for Inflatable Play Equipment
+
+      Essex Inflatables is a specialist testing and repair facility serving operators of inflatable play equipment throughout Essex and the Southeast. We provide the essential behind-the-scenes services that operators need to keep their equipment safe, compliant and operational. Our facility has been repairing inflatable equipment since 1994 and conducting safety inspections since 1997.
+
+      Unlike hire companies, we work exclusively with operators and businesses to maintain their inflatable equipment. Our comprehensive services include annual PIPA inspections for health and safety compliance, professional repairs for all types of damage, and supply of replacement parts and equipment.
+
+      ### Safety Inspections
+
+      We became a PIPA Inspection Body in 2004 and provide HSE-endorsed inspection services using the EU standard BS EN 14960. Our certified inspectors conduct thorough annual inspections to ensure your equipment meets all health and safety requirements. We currently have one PIPA inspector on our team, soon expanding to two or three inspectors to meet growing demand.
+
+      ### Professional Repairs
+
+      Our in-house repair facility handles all types of inflatable damage and maintenance requirements. From bed stitches and panel replacements to complete structural repairs, we use professional-grade equipment including air-cooled twin needle sewing machines and the highest quality PVC materials and thread. All repairs are completed at our dedicated facility in the Hullbridge area, ensuring consistent quality and proper workspace for even the most complex repairs.
+
+      ### Operator Support Services
+
+      We understand the unique needs of inflatable operators and provide comprehensive support including emergency call-out services, pre-examination checks for equipment assessment, and supply of essential parts and second-hand equipment when available. Our team provides expert advice based on decades of experience in the industry.
 ---
-![Essex Inflatables](/images/essex-banner.jpg)
-
-## Professional Testing and Repair Facility for Inflatable Play Equipment
-
-Essex Inflatables is a specialist testing and repair facility serving operators of inflatable play equipment throughout Essex and the Southeast. We provide the essential behind-the-scenes services that operators need to keep their equipment safe, compliant and operational. Our facility has been repairing inflatable equipment since 1994 and conducting safety inspections since 1997.
-
-Unlike hire companies, we work exclusively with operators and businesses to maintain their inflatable equipment. Our comprehensive services include annual PIPA inspections for health and safety compliance, professional repairs for all types of damage, and supply of replacement parts and equipment.
-
-### Safety Inspections
-
-We became a PIPA Inspection Body in 2004 and provide HSE-endorsed inspection services using the EU standard BS EN 14960. Our certified inspectors conduct thorough annual inspections to ensure your equipment meets all health and safety requirements. We currently have one PIPA inspector on our team, soon expanding to two or three inspectors to meet growing demand.
-
-### Professional Repairs
-
-Our in-house repair facility handles all types of inflatable damage and maintenance requirements. From bed stitches and panel replacements to complete structural repairs, we use professional-grade equipment including air-cooled twin needle sewing machines and the highest quality PVC materials and thread. All repairs are completed at our dedicated facility in the Hullbridge area, ensuring consistent quality and proper workspace for even the most complex repairs.
-
-### Operator Support Services
-
-We understand the unique needs of inflatable operators and provide comprehensive support including emergency call-out services, pre-examination checks for equipment assessment, and supply of essential parts and second-hand equipment when available. Our team provides expert advice based on decades of experience in the industry.

--- a/pages/home.md
+++ b/pages/home.md
@@ -8,7 +8,7 @@ meta_title: Essex Inflatables - Testing & Repair Facility for Inflatable Equipme
 eleventyNavigation:
   key: Home
   order: 0
-layout: design-system-base.md
+layout: design-system-base.html
 permalink: /
 blocks:
   - type: hero

--- a/pages/hse-best-practices.md
+++ b/pages/hse-best-practices.md
@@ -6,61 +6,67 @@ meta_description: Understanding HSE requirements, PIPA testing standards, and sa
 eleventyNavigation:
   key: HSE Best Practice
   order: 4
+layout: design-system-base.md
 permalink: /hse-best-practice/
 redirect_from:
   - /HSE Best Practice.html
+blocks:
+  - type: hero
+    title: HSE Best Practice
+  - type: markdown
+    content: |
+      ![TIPE Logo](/images/tipe-logo.jpg)
+
+      ## HSE Best Practices for Inflatable Play Equipment
+
+      ### Understanding Safety Requirements
+
+      The Health and Safety Executive (HSE) sets clear expectations for operators of inflatable play equipment. Under the Health and Safety at Work Act 1974 (HASAWA) and the Provision and Use of Work Equipment Regulations 1998 (PUWER), operators must ensure their equipment is safe for public use. Regular inspection and maintenance are not just best practice but legal requirements that protect both operators and users.
+
+      Essex Inflatables has been conducting safety inspections since 1997 under HSE recommendations for best practice. We became a certified PIPA Inspection Body in 2004, providing operators with the assurance that their equipment meets all necessary safety standards.
+
+      ### PIPA Testing and BS EN 14960 Standards
+
+      PIPA (Performance Inflatable Play Accreditation) is the HSE-endorsed inspection scheme for inflatable play equipment. The scheme follows BS EN 14960, the European standard that governs the safety requirements and test methods for inflatable play equipment. This comprehensive standard covers all aspects of inflatable safety from design and manufacture through to operation and maintenance.
+
+      Our PIPA inspections examine structural integrity, ensuring frames and supports are secure and free from defects. We inspect seams and fabric condition, checking for wear, tears, and potential failure points that could compromise safety. Air retention is tested to verify inflatables maintain appropriate pressure for safe operation. Anchor points are examined for security and wear, as these are critical safety features. Electrical systems, including blowers and connections, are checked for safety and proper operation.
+
+      ### The Importance of Annual Testing
+
+      Annual testing is an annual inspection scheme for health and safety endorsed by the HSE. Regular inspections identify developing issues before they become safety hazards, protecting operators from potential liability and ensuring continued safe operation. Whilst PIPA testing is not legally mandatory, HSE guidance clearly states that operators using accredited schemes like PIPA or ADIPS demonstrate compliance with best practices.
+
+      Operators who choose not to use accredited testing schemes must be able to prove the competence of their testing personnel if required by enforcement authorities. This places significant burden on operators to demonstrate their testing meets equivalent standards to accredited schemes.
+
+      ### Our Testing Credentials
+
+      All our testers are certified under the PIPA scheme and maintain current training on safety standards and regulations. We have the necessary equipment to conduct thorough inspections according to BS EN 14960 requirements. Our team follows strict safety protocols during all inspections and maintains comprehensive insurance coverage for professional testing services.
+
+      We also hold PAT test certification, allowing us to test electrical equipment such as blowers during inspections. This comprehensive approach ensures all aspects of your inflatable equipment meet safety requirements.
+
+      ### Maintenance Between Inspections
+
+      Annual testing forms the foundation of safety compliance, but operators must maintain equipment between inspections. Regular visual checks should identify obvious damage or wear before each use. Cleaning and proper storage extend equipment life and maintain safety standards. Minor repairs should be addressed promptly to prevent deterioration.
+
+      Our repair facility provides professional maintenance services to keep equipment in optimal condition between annual inspections. We handle everything from minor patches to major structural repairs, using professional materials and equipment to ensure lasting repairs.
+
+      ### Legal Compliance and Insurance
+
+      Using a certified PIPA testing service provides documented compliance with HSE best practices. This documentation is essential for insurance purposes and demonstrates due diligence in equipment maintenance. Many insurance policies require annual testing by accredited schemes as a condition of coverage.
+
+      In the event of an incident, having current PIPA certification and maintenance records provides crucial evidence of proper equipment care. This documentation can be the difference between a successful insurance claim and potential legal liability.
+
+      ### Booking Your Safety Inspection
+
+      Schedule your annual PIPA inspection well before certificate expiry to ensure continuous compliance. Contact us with details of your equipment, location, and preferred inspection dates. We provide written quotes for all inspection services and work around your operational schedule to minimise disruption.
+
+      For operators new to PIPA testing, we can explain the process and requirements in detail. Our team guides you through the inspection process and helps you understand how to maintain compliance throughout the year.
+
+      ### Contact Us for Safety Compliance
+
+      Essex Inflatables is committed to helping operators maintain safe, compliant inflatable equipment. Our combination of PIPA testing, professional repairs, and expert advice ensures your equipment meets all safety requirements.
+
+      Phone: 01268 569302
+      Email: enquiries@essexinflatables.co.uk
+
+      Your safety compliance is our priority. Contact us today to schedule your PIPA inspection or discuss your equipment maintenance needs.
 ---
-![TIPE Logo](/images/tipe-logo.jpg)
-
-## HSE Best Practices for Inflatable Play Equipment
-
-### Understanding Safety Requirements
-
-The Health and Safety Executive (HSE) sets clear expectations for operators of inflatable play equipment. Under the Health and Safety at Work Act 1974 (HASAWA) and the Provision and Use of Work Equipment Regulations 1998 (PUWER), operators must ensure their equipment is safe for public use. Regular inspection and maintenance are not just best practice but legal requirements that protect both operators and users.
-
-Essex Inflatables has been conducting safety inspections since 1997 under HSE recommendations for best practice. We became a certified PIPA Inspection Body in 2004, providing operators with the assurance that their equipment meets all necessary safety standards.
-
-### PIPA Testing and BS EN 14960 Standards
-
-PIPA (Performance Inflatable Play Accreditation) is the HSE-endorsed inspection scheme for inflatable play equipment. The scheme follows BS EN 14960, the European standard that governs the safety requirements and test methods for inflatable play equipment. This comprehensive standard covers all aspects of inflatable safety from design and manufacture through to operation and maintenance.
-
-Our PIPA inspections examine structural integrity, ensuring frames and supports are secure and free from defects. We inspect seams and fabric condition, checking for wear, tears, and potential failure points that could compromise safety. Air retention is tested to verify inflatables maintain appropriate pressure for safe operation. Anchor points are examined for security and wear, as these are critical safety features. Electrical systems, including blowers and connections, are checked for safety and proper operation.
-
-### The Importance of Annual Testing
-
-Annual testing is an annual inspection scheme for health and safety endorsed by the HSE. Regular inspections identify developing issues before they become safety hazards, protecting operators from potential liability and ensuring continued safe operation. Whilst PIPA testing is not legally mandatory, HSE guidance clearly states that operators using accredited schemes like PIPA or ADIPS demonstrate compliance with best practices.
-
-Operators who choose not to use accredited testing schemes must be able to prove the competence of their testing personnel if required by enforcement authorities. This places significant burden on operators to demonstrate their testing meets equivalent standards to accredited schemes.
-
-### Our Testing Credentials
-
-All our testers are certified under the PIPA scheme and maintain current training on safety standards and regulations. We have the necessary equipment to conduct thorough inspections according to BS EN 14960 requirements. Our team follows strict safety protocols during all inspections and maintains comprehensive insurance coverage for professional testing services.
-
-We also hold PAT test certification, allowing us to test electrical equipment such as blowers during inspections. This comprehensive approach ensures all aspects of your inflatable equipment meet safety requirements.
-
-### Maintenance Between Inspections
-
-Annual testing forms the foundation of safety compliance, but operators must maintain equipment between inspections. Regular visual checks should identify obvious damage or wear before each use. Cleaning and proper storage extend equipment life and maintain safety standards. Minor repairs should be addressed promptly to prevent deterioration.
-
-Our repair facility provides professional maintenance services to keep equipment in optimal condition between annual inspections. We handle everything from minor patches to major structural repairs, using professional materials and equipment to ensure lasting repairs.
-
-### Legal Compliance and Insurance
-
-Using a certified PIPA testing service provides documented compliance with HSE best practices. This documentation is essential for insurance purposes and demonstrates due diligence in equipment maintenance. Many insurance policies require annual testing by accredited schemes as a condition of coverage.
-
-In the event of an incident, having current PIPA certification and maintenance records provides crucial evidence of proper equipment care. This documentation can be the difference between a successful insurance claim and potential legal liability.
-
-### Booking Your Safety Inspection
-
-Schedule your annual PIPA inspection well before certificate expiry to ensure continuous compliance. Contact us with details of your equipment, location, and preferred inspection dates. We provide written quotes for all inspection services and work around your operational schedule to minimise disruption.
-
-For operators new to PIPA testing, we can explain the process and requirements in detail. Our team guides you through the inspection process and helps you understand how to maintain compliance throughout the year.
-
-### Contact Us for Safety Compliance
-
-Essex Inflatables is committed to helping operators maintain safe, compliant inflatable equipment. Our combination of PIPA testing, professional repairs, and expert advice ensures your equipment meets all safety requirements.
-
-Phone: 01268 569302
-Email: enquiries@essexinflatables.co.uk
-
-Your safety compliance is our priority. Contact us today to schedule your PIPA inspection or discuss your equipment maintenance needs.

--- a/pages/hse-best-practices.md
+++ b/pages/hse-best-practices.md
@@ -6,7 +6,7 @@ meta_description: Understanding HSE requirements, PIPA testing standards, and sa
 eleventyNavigation:
   key: HSE Best Practice
   order: 4
-layout: design-system-base.md
+layout: design-system-base.html
 permalink: /hse-best-practice/
 redirect_from:
   - /HSE Best Practice.html

--- a/pages/links.md
+++ b/pages/links.md
@@ -5,25 +5,30 @@ meta_title: Links
 eleventyNavigation:
   key: Links
   order: 6
+layout: design-system-base.md
 permalink: /links/
 redirect_from:
   - /Links.html
+blocks:
+  - type: hero
+    title: Links
+  - type: markdown
+    content: |
+      Ellis Leisure (Bouncy Castle Hire Essex)
+
+      Click Banner For Their Website
+
+      [![banner](/images/ellis-leisure-banner.jpg)](http://www.ellisleisure.co.uk/)
+
+      Tipe (Inflated Play Enterprise)
+
+      Click Banner For Their Website
+
+      [![tipe](/images/tipe-logo.png)](http://www.tipe.co.uk/)
+
+      PIPA (Performance Inflatable Play Accreditation)
+
+      Click Logo For Their Website
+
+      [![PIPA](/images/pipa-logo.png)](https://www.pipa.org.uk/)
 ---
-
-Ellis Leisure (Bouncy Castle Hire Essex)
-
-Click Banner For Their Website
-
-[![banner](/images/ellis-leisure-banner.jpg)](http://www.ellisleisure.co.uk/)
-
-Tipe (Inflated Play Enterprise)
-
-Click Banner For Their Website
-
-[![tipe](/images/tipe-logo.png)](http://www.tipe.co.uk/)
-
-PIPA (Performance Inflatable Play Accreditation)
-
-Click Logo For Their Website
-
-[![PIPA](/images/pipa-logo.png)](https://www.pipa.org.uk/)

--- a/pages/links.md
+++ b/pages/links.md
@@ -5,7 +5,7 @@ meta_title: Links
 eleventyNavigation:
   key: Links
   order: 6
-layout: design-system-base.md
+layout: design-system-base.html
 permalink: /links/
 redirect_from:
   - /Links.html

--- a/pages/news.md
+++ b/pages/news.md
@@ -5,7 +5,7 @@ meta_title: News
 eleventyNavigation:
   key: News
   order: 3
-layout: design-system-base.md
+layout: design-system-base.html
 permalink: /news/
 blocks:
   - type: hero

--- a/pages/news.md
+++ b/pages/news.md
@@ -5,10 +5,14 @@ meta_title: News
 eleventyNavigation:
   key: News
   order: 3
-layout: news-archive.html
+layout: design-system-base.md
 permalink: /news/
+blocks:
+  - type: hero
+    title: News
+  - type: markdown
+    content: |
+      ## Congue Ipsum
+
+      Integer feugiat iaculis augue, in hendrerit sapien dapibus et. Mauris vitae est auctor, pellentesque nisl.
 ---
-
-## Congue Ipsum
-
-Integer feugiat iaculis augue, in hendrerit sapien dapibus et. Mauris vitae est auctor, pellentesque nisl.

--- a/pages/not-found.md
+++ b/pages/not-found.md
@@ -3,7 +3,7 @@ header_image: /images/bouncy-slide.jpg
 header_text: Not Found
 meta_description:
 meta_title: Not Found
-layout: design-system-base.md
+layout: design-system-base.html
 permalink: /not_found.html
 blocks:
   - type: hero

--- a/pages/not-found.md
+++ b/pages/not-found.md
@@ -3,10 +3,14 @@ header_image: /images/bouncy-slide.jpg
 header_text: Not Found
 meta_description:
 meta_title: Not Found
-
+layout: design-system-base.md
 permalink: /not_found.html
+blocks:
+  - type: hero
+    title: Not Found
+  - type: markdown
+    content: |
+      ## Page Not Found
+
+      Whoops! It looks like you followed an invalid link - **[click here to go back to the homepage](/)**.
 ---
-
-## Page Not Found
-
-Whoops! It looks like you followed an invalid link - **[click here to go back to the homepage](/)**.

--- a/pages/pipa-inspections.md
+++ b/pages/pipa-inspections.md
@@ -7,7 +7,7 @@ subtitle: Annual Safety Inspections for Inflatable Play Equipment
 eleventyNavigation:
   key: PIPA Inspections
   order: 2
-layout: design-system-base.md
+layout: design-system-base.html
 permalink: /pipa-inspections/
 blocks:
   - type: hero

--- a/pages/pipa-inspections.md
+++ b/pages/pipa-inspections.md
@@ -7,64 +7,69 @@ subtitle: Annual Safety Inspections for Inflatable Play Equipment
 eleventyNavigation:
   key: PIPA Inspections
   order: 2
-layout: contact.html
+layout: design-system-base.md
 permalink: /pipa-inspections/
+blocks:
+  - type: hero
+    title: PIPA Inspections
+    lead: Annual Safety Inspections for Inflatable Play Equipment
+  - type: markdown
+    content: |
+      ## PIPA Testing and Safety Inspection Services
+
+      Essex Inflatables has been a certified PIPA Inspection Body since 2004, providing comprehensive annual inspection services for inflatable play equipment throughout Essex and the Southeast. PIPA (Performance Inflatable Play Accreditation) is the HSE-endorsed inspection scheme that ensures inflatable play equipment meets essential health and safety standards.
+
+      ### What is PIPA Testing?
+
+      PIPA is an annual inspection scheme for health and safety endorsed by the HSE (Health and Safety Executive). The scheme ensures that inflatable play equipment is regularly inspected, properly maintained, and safe for public use. Our inspections follow the EU standard BS EN 14960, which sets out the safety requirements and test methods for inflatable play equipment.
+
+      All operators of inflatable play equipment used for commercial purposes require annual PIPA inspections to comply with health and safety regulations. Regular inspections help identify potential issues before they become safety hazards, ensuring the continued safe operation of your equipment and protecting both operators and users.
+
+      ### Our Inspection Process
+
+      Our certified PIPA inspectors conduct thorough examinations of all aspects of your inflatable equipment. The inspection covers structural integrity, seam strength, anchor points, and overall condition. We check for wear and tear, damage, and any modifications that might affect safety. Each piece of equipment is tested according to strict protocols to ensure it meets all required standards.
+
+      Following the inspection, we provide detailed documentation including your PIPA certificate, inspection report, and any recommendations for maintenance or repairs. If issues are identified during inspection, we can provide quotes for necessary repairs at our facility, ensuring your equipment returns to full compliance quickly.
+
+      ### Equipment We Inspect
+
+      Our PIPA inspection service covers all continuous flow land inflatables including:
+
+      - Bouncy castles of all sizes and designs
+      - Assault courses and obstacle runs
+      - Slides including combination units
+      - Disco domes and party inflatables
+      - Flat play beds and soft play areas
+      - Enclosed units and themed castles
+      - Multi-play combination equipment
+      - Other continuous flow inflatables
+
+      We also provide annual safety inspections for equipment that falls outside PIPA's remit, including pole joust, pool inflatables, barfly units, gladiator duels, human table football, and other specialised inflatable equipment.
+
+      ### Inspection Scheduling and Coverage
+
+      We travel to operator locations throughout Essex, London, Kent, Hertfordshire, Surrey, and the broader Southeast region. Our inspection team can visit council facilities, schools, storage facilities, and operator premises. We understand that access requirements vary, and we accommodate out-of-hours inspections for venues that require them.
+
+      Call-out charges apply based on location and timing requirements. Standard hours inspections are available at our standard call-out rate, whilst venues requiring evening or weekend access may incur additional charges. We work with operators to schedule inspections at convenient times that minimise disruption to their business operations.
+
+      ### Our Inspection Team
+
+      Our inspection team consists of certified PIPA inspectors with extensive experience in inflatable equipment safety. We currently have one qualified PIPA inspector on our team, with plans to expand to two or three inspectors to meet growing demand and reduce waiting times for inspections.
+
+      All our inspectors are certified under the PIPA scheme and regularly update their training to stay current with safety standards and regulations. We maintain comprehensive insurance coverage and follow all safety protocols during inspections. Our team also holds PAT test certification, allowing us to test electrical equipment such as blowers during inspections.
+
+      ### How It Works
+
+      1. **Get in touch** — phone or email with the number and types of inflatables, your location, and any access requirements.
+      2. **Written quote** — we send a written quote by email so pricing and scope are clear up front.
+      3. **Inspection** — our certified PIPA inspector visits at a mutually convenient time (including out-of-hours where needed).
+      4. **Certificate & report** — passing equipment receives a PIPA certificate and a full inspection report. Any issues identified can be quoted for repair at our facility.
+
+      ### Booking Your PIPA Inspection
+
+      To book your annual PIPA inspection, contact us by phone or email with details of your equipment and preferred inspection dates. We recommend booking well in advance of your certificate expiry to ensure availability and avoid any gaps in certification.
+
+      ### Book Your Inspection
+
+      Call **[01268 569302](tel:01268569302)** or email **[enquiries@essexinflatables.co.uk](mailto:enquiries@essexinflatables.co.uk)** — or use the form below to send us an enquiry.
 ---
-
-## PIPA Testing and Safety Inspection Services
-
-Essex Inflatables has been a certified PIPA Inspection Body since 2004, providing comprehensive annual inspection services for inflatable play equipment throughout Essex and the Southeast. PIPA (Performance Inflatable Play Accreditation) is the HSE-endorsed inspection scheme that ensures inflatable play equipment meets essential health and safety standards.
-
-### What is PIPA Testing?
-
-PIPA is an annual inspection scheme for health and safety endorsed by the HSE (Health and Safety Executive). The scheme ensures that inflatable play equipment is regularly inspected, properly maintained, and safe for public use. Our inspections follow the EU standard BS EN 14960, which sets out the safety requirements and test methods for inflatable play equipment.
-
-All operators of inflatable play equipment used for commercial purposes require annual PIPA inspections to comply with health and safety regulations. Regular inspections help identify potential issues before they become safety hazards, ensuring the continued safe operation of your equipment and protecting both operators and users.
-
-### Our Inspection Process
-
-Our certified PIPA inspectors conduct thorough examinations of all aspects of your inflatable equipment. The inspection covers structural integrity, seam strength, anchor points, and overall condition. We check for wear and tear, damage, and any modifications that might affect safety. Each piece of equipment is tested according to strict protocols to ensure it meets all required standards.
-
-Following the inspection, we provide detailed documentation including your PIPA certificate, inspection report, and any recommendations for maintenance or repairs. If issues are identified during inspection, we can provide quotes for necessary repairs at our facility, ensuring your equipment returns to full compliance quickly.
-
-### Equipment We Inspect
-
-Our PIPA inspection service covers all continuous flow land inflatables including:
-
-- Bouncy castles of all sizes and designs
-- Assault courses and obstacle runs
-- Slides including combination units
-- Disco domes and party inflatables
-- Flat play beds and soft play areas
-- Enclosed units and themed castles
-- Multi-play combination equipment
-- Other continuous flow inflatables
-
-We also provide annual safety inspections for equipment that falls outside PIPA's remit, including pole joust, pool inflatables, barfly units, gladiator duels, human table football, and other specialised inflatable equipment.
-
-### Inspection Scheduling and Coverage
-
-We travel to operator locations throughout Essex, London, Kent, Hertfordshire, Surrey, and the broader Southeast region. Our inspection team can visit council facilities, schools, storage facilities, and operator premises. We understand that access requirements vary, and we accommodate out-of-hours inspections for venues that require them.
-
-Call-out charges apply based on location and timing requirements. Standard hours inspections are available at our standard call-out rate, whilst venues requiring evening or weekend access may incur additional charges. We work with operators to schedule inspections at convenient times that minimise disruption to their business operations.
-
-### Our Inspection Team
-
-Our inspection team consists of certified PIPA inspectors with extensive experience in inflatable equipment safety. We currently have one qualified PIPA inspector on our team, with plans to expand to two or three inspectors to meet growing demand and reduce waiting times for inspections.
-
-All our inspectors are certified under the PIPA scheme and regularly update their training to stay current with safety standards and regulations. We maintain comprehensive insurance coverage and follow all safety protocols during inspections. Our team also holds PAT test certification, allowing us to test electrical equipment such as blowers during inspections.
-
-### How It Works
-
-1. **Get in touch** — phone or email with the number and types of inflatables, your location, and any access requirements.
-2. **Written quote** — we send a written quote by email so pricing and scope are clear up front.
-3. **Inspection** — our certified PIPA inspector visits at a mutually convenient time (including out-of-hours where needed).
-4. **Certificate & report** — passing equipment receives a PIPA certificate and a full inspection report. Any issues identified can be quoted for repair at our facility.
-
-### Booking Your PIPA Inspection
-
-To book your annual PIPA inspection, contact us by phone or email with details of your equipment and preferred inspection dates. We recommend booking well in advance of your certificate expiry to ensure availability and avoid any gaps in certification.
-
-### Book Your Inspection
-
-Call **[01268 569302](tel:01268569302)** or email **[enquiries@essexinflatables.co.uk](mailto:enquiries@essexinflatables.co.uk)** — or use the form below to send us an enquiry.

--- a/pages/repairs.md
+++ b/pages/repairs.md
@@ -7,74 +7,79 @@ subtitle: Professional In-House Repair Facility
 eleventyNavigation:
   key: Repairs
   order: 3
-layout: base.html
+layout: design-system-base.md
 permalink: /repairs/
+blocks:
+  - type: hero
+    title: Repair Services
+    lead: Professional In-House Repair Facility
+  - type: markdown
+    content: |
+      ## Professional Inflatable Repair Services
+
+      Essex Inflatables has been repairing inflatable play equipment since 1994, providing operators with reliable, high-quality repair services from our dedicated facility. Our experienced team handles everything from minor patches to complete structural rebuilds, using professional-grade equipment and materials to ensure lasting repairs.
+
+      ### Our Repair Facility
+
+      All repairs are completed at our dedicated workshop facility in the Hullbridge area. This in-house approach ensures consistent quality control, proper working conditions, and access to all necessary equipment and materials. We do not currently offer mobile on-site repairs, as our facility provides the controlled environment necessary for professional-quality work.
+
+      Our workshop is equipped with air-cooled twin needle sewing machines specifically designed for heavy-duty PVC work. We maintain extensive stocks of high-quality PVC materials in various colours and weights, along with professional-grade thread that ensures strong, durable repairs. This investment in proper equipment and materials means we can handle repairs that others might consider beyond salvage.
+
+      ### Types of Repairs We Undertake
+
+      Our repair services cover all aspects of inflatable maintenance and damage repair. We specialise in bed stitches, which are critical for the structural integrity of bouncy castles. Back panel stitches are another common repair we handle, ensuring the walls and structures of inflatables remain secure and safe.
+
+      Panel replacement is a significant part of our work. Whether it is a torn base sheet, damaged wall panel, or worn bed section, we can fabricate and install replacement panels that match the original specifications. We recently completed a full section panel replacement on the base of a jungle assault course, where the operators had torn the base sheet whilst loading it into their van.
+
+      We repair rips and tears of all sizes, from small punctures to major structural damage. Our technicians assess each tear to determine the best repair method, whether that is patching, stitching, or panel replacement. Anchor points, which bear significant stress during use, are frequently replaced or reinforced to ensure continued safe operation.
+
+      Internal repairs form a specialised part of our services. We install new zips in step-on stools, replace bed panels inside castle structures, and repair diaphragms within the internal framework. These repairs often require careful disassembly and reassembly, work that benefits from our controlled workshop environment.
+
+      ### Our Repair Process
+
+      When equipment arrives at our facility, we conduct a thorough assessment to identify all issues requiring attention. We examine not just the reported damage but check the entire inflatable for any additional problems that might affect safety or longevity. This comprehensive approach helps operators avoid unexpected failures and extends equipment life.
+
+      Following assessment, we provide a detailed quote based on the size of the inflatable, extent of damage, and complexity of required repairs. Different manufacturer designs require different approaches, as some castles provide easier internal access than others. Chinese-manufactured units, for example, often require different techniques than European-made equipment.
+
+      Once repairs are approved, our technicians work systematically through each issue, ensuring all work meets our quality standards. We use matching materials wherever possible and ensure all repairs are both functional and aesthetically acceptable. After completion, we conduct final checks to ensure the inflatable is ready for safe operation.
+
+      ### Pre-Examination Service
+
+      For operators unsure about repair requirements or costs, we offer a pre-examination service for £30. This service includes a thorough inspection of your equipment, identification of all issues requiring attention, and a detailed written quote for necessary repairs. This allows operators to make informed decisions about repair versus replacement and budget accordingly for maintenance costs.
+
+      During pre-examination, we can discuss repair options with operators, explaining what work is essential for safety compliance versus what might be cosmetic or optional. This consultation helps operators prioritise repairs according to their budget and operational needs.
+
+      ### Emergency Repair Services
+
+      We understand that damaged equipment means lost revenue for operators. We offer emergency call-out services for urgent situations, though equipment must still be brought to our facility for repair. Our emergency service helps operators get critical repairs completed quickly, minimising downtime during peak operating seasons.
+
+      Call-out charges vary depending on location, time of day, and urgency. Standard business hours call-outs are charged at our regular rate, whilst out-of-hours emergency services incur additional charges. We provide clear pricing for emergency services when operators contact us, ensuring no surprises.
+
+      ### Blower and Fan Maintenance
+
+      Beyond inflatable repairs, we service and maintain the blowers and fans essential for operating inflatable equipment. Our services include complete strip-down and cleaning of fan units, replacement of worn components, fan repair, and testing to ensure optimal performance. We also provide PAT testing for electrical safety compliance.
+
+      Regular blower maintenance extends equipment life and ensures consistent inflation pressure. We stock common replacement parts and can source components for most blower models. When repair is not economical, we can advise on suitable replacement options from our selection of new and reconditioned units.
+
+      ### Repair Materials
+
+      For operators who handle minor repairs themselves, we stock professional-grade repair materials including:
+
+      - PVC patches in various colours
+      - Professional adhesives and solvents
+      - Heavy-duty thread for stitching repairs
+      - Repair kits for emergency field repairs
+      - Replacement zips and fastenings
+
+      Contact us for current stock and pricing on any of the above.
+
+      ### Getting Your Equipment Repaired
+
+      To arrange repairs, contact us with details of the damage and, if possible, photographs showing the affected areas. This helps us provide initial estimates and advise on whether the repair is economically viable. We can then arrange for you to deliver the equipment to our facility or discuss collection options for larger items.
+
+      We aim to complete most repairs within a reasonable timeframe, though complex jobs or busy periods may extend turnaround times. We keep operators informed throughout the repair process and can provide updates on progress as needed.
+
+      ### Request a Repair Quote
+
+      Call **[01268 569302](tel:01268569302)** or email **[enquiries@essexinflatables.co.uk](mailto:enquiries@essexinflatables.co.uk)** with photographs of the damage and details of your equipment, or use our [contact form](/contact/) to send an enquiry.
 ---
-
-## Professional Inflatable Repair Services
-
-Essex Inflatables has been repairing inflatable play equipment since 1994, providing operators with reliable, high-quality repair services from our dedicated facility. Our experienced team handles everything from minor patches to complete structural rebuilds, using professional-grade equipment and materials to ensure lasting repairs.
-
-### Our Repair Facility
-
-All repairs are completed at our dedicated workshop facility in the Hullbridge area. This in-house approach ensures consistent quality control, proper working conditions, and access to all necessary equipment and materials. We do not currently offer mobile on-site repairs, as our facility provides the controlled environment necessary for professional-quality work.
-
-Our workshop is equipped with air-cooled twin needle sewing machines specifically designed for heavy-duty PVC work. We maintain extensive stocks of high-quality PVC materials in various colours and weights, along with professional-grade thread that ensures strong, durable repairs. This investment in proper equipment and materials means we can handle repairs that others might consider beyond salvage.
-
-### Types of Repairs We Undertake
-
-Our repair services cover all aspects of inflatable maintenance and damage repair. We specialise in bed stitches, which are critical for the structural integrity of bouncy castles. Back panel stitches are another common repair we handle, ensuring the walls and structures of inflatables remain secure and safe.
-
-Panel replacement is a significant part of our work. Whether it is a torn base sheet, damaged wall panel, or worn bed section, we can fabricate and install replacement panels that match the original specifications. We recently completed a full section panel replacement on the base of a jungle assault course, where the operators had torn the base sheet whilst loading it into their van.
-
-We repair rips and tears of all sizes, from small punctures to major structural damage. Our technicians assess each tear to determine the best repair method, whether that is patching, stitching, or panel replacement. Anchor points, which bear significant stress during use, are frequently replaced or reinforced to ensure continued safe operation.
-
-Internal repairs form a specialised part of our services. We install new zips in step-on stools, replace bed panels inside castle structures, and repair diaphragms within the internal framework. These repairs often require careful disassembly and reassembly, work that benefits from our controlled workshop environment.
-
-### Our Repair Process
-
-When equipment arrives at our facility, we conduct a thorough assessment to identify all issues requiring attention. We examine not just the reported damage but check the entire inflatable for any additional problems that might affect safety or longevity. This comprehensive approach helps operators avoid unexpected failures and extends equipment life.
-
-Following assessment, we provide a detailed quote based on the size of the inflatable, extent of damage, and complexity of required repairs. Different manufacturer designs require different approaches, as some castles provide easier internal access than others. Chinese-manufactured units, for example, often require different techniques than European-made equipment.
-
-Once repairs are approved, our technicians work systematically through each issue, ensuring all work meets our quality standards. We use matching materials wherever possible and ensure all repairs are both functional and aesthetically acceptable. After completion, we conduct final checks to ensure the inflatable is ready for safe operation.
-
-### Pre-Examination Service
-
-For operators unsure about repair requirements or costs, we offer a pre-examination service for £30. This service includes a thorough inspection of your equipment, identification of all issues requiring attention, and a detailed written quote for necessary repairs. This allows operators to make informed decisions about repair versus replacement and budget accordingly for maintenance costs.
-
-During pre-examination, we can discuss repair options with operators, explaining what work is essential for safety compliance versus what might be cosmetic or optional. This consultation helps operators prioritise repairs according to their budget and operational needs.
-
-### Emergency Repair Services
-
-We understand that damaged equipment means lost revenue for operators. We offer emergency call-out services for urgent situations, though equipment must still be brought to our facility for repair. Our emergency service helps operators get critical repairs completed quickly, minimising downtime during peak operating seasons.
-
-Call-out charges vary depending on location, time of day, and urgency. Standard business hours call-outs are charged at our regular rate, whilst out-of-hours emergency services incur additional charges. We provide clear pricing for emergency services when operators contact us, ensuring no surprises.
-
-### Blower and Fan Maintenance
-
-Beyond inflatable repairs, we service and maintain the blowers and fans essential for operating inflatable equipment. Our services include complete strip-down and cleaning of fan units, replacement of worn components, fan repair, and testing to ensure optimal performance. We also provide PAT testing for electrical safety compliance.
-
-Regular blower maintenance extends equipment life and ensures consistent inflation pressure. We stock common replacement parts and can source components for most blower models. When repair is not economical, we can advise on suitable replacement options from our selection of new and reconditioned units.
-
-### Repair Materials
-
-For operators who handle minor repairs themselves, we stock professional-grade repair materials including:
-
-- PVC patches in various colours
-- Professional adhesives and solvents
-- Heavy-duty thread for stitching repairs
-- Repair kits for emergency field repairs
-- Replacement zips and fastenings
-
-Contact us for current stock and pricing on any of the above.
-
-### Getting Your Equipment Repaired
-
-To arrange repairs, contact us with details of the damage and, if possible, photographs showing the affected areas. This helps us provide initial estimates and advise on whether the repair is economically viable. We can then arrange for you to deliver the equipment to our facility or discuss collection options for larger items.
-
-We aim to complete most repairs within a reasonable timeframe, though complex jobs or busy periods may extend turnaround times. We keep operators informed throughout the repair process and can provide updates on progress as needed.
-
-### Request a Repair Quote
-
-Call **[01268 569302](tel:01268569302)** or email **[enquiries@essexinflatables.co.uk](mailto:enquiries@essexinflatables.co.uk)** with photographs of the damage and details of your equipment, or use our [contact form](/contact/) to send an enquiry.

--- a/pages/repairs.md
+++ b/pages/repairs.md
@@ -7,7 +7,7 @@ subtitle: Professional In-House Repair Facility
 eleventyNavigation:
   key: Repairs
   order: 3
-layout: design-system-base.md
+layout: design-system-base.html
 permalink: /repairs/
 blocks:
   - type: hero

--- a/pages/services.md
+++ b/pages/services.md
@@ -6,40 +6,44 @@ meta_description: Comprehensive repair and PIPA inspection services for inflatab
 eleventyNavigation:
   key: Services
   order: 1
-layout: categories.html
+layout: design-system-base.md
 permalink: /services/
+blocks:
+  - type: hero
+    title: Our Services
+  - type: markdown
+    content: |
+      ## Our Services at a Glance
+
+      Essex Inflatables provides the essential behind-the-scenes services that operators of inflatable play equipment rely on — from certified safety inspections to professional in-house repairs and the spare parts that keep your kit on the road.
+
+      Select a service below for full details, pricing, and how to book.
+
+      ### [Repair Services](/repairs/)
+
+      In-house repairs for inflatable play equipment at our Hullbridge workshop, including panel replacements, bed and back panel stitching, anchor points, internal repairs, blower and fan maintenance, and repair materials. Pre-examination service available for £30.
+
+      ### [PIPA Inspections](/pipa-inspections/)
+
+      Annual PIPA safety inspections by a certified PIPA Inspection Body (since 2004), following BS EN 14960. Covers bouncy castles, assault courses, slides, disco domes and more, plus non-PIPA annual inspections for pole joust, pool inflatables, gladiators and similar.
+
+      ### Parts & Equipment
+
+      Stakes, fans, blowers, replacement parts, and second-hand equipment when available. Contact us for current stock and pricing.
+
+      ### [HSE Best Practice](/hse-best-practice/)
+
+      Guidance on your responsibilities as an operator under HSE rules, BS EN 14960, and the annual testing process.
+
+      ### Service Coverage Area
+
+      We serve operators throughout Essex, London, Kent, Hertfordshire, Surrey, and the broader Southeast region. For PIPA inspections we travel to council facilities, schools, and operator locations. For repairs, equipment must be delivered to our Hullbridge facility.
+
+      ### Get in Touch
+
+      Phone: [01268 569302](tel:01268569302) · Email: [enquiries@essexinflatables.co.uk](mailto:enquiries@essexinflatables.co.uk)
+
+      Or use our [contact page](/contact/) to send an enquiry.
+
+      ![](/images/dad3.jpg)
 ---
-
-## Our Services at a Glance
-
-Essex Inflatables provides the essential behind-the-scenes services that operators of inflatable play equipment rely on — from certified safety inspections to professional in-house repairs and the spare parts that keep your kit on the road.
-
-Select a service below for full details, pricing, and how to book.
-
-### [Repair Services](/repairs/)
-
-In-house repairs for inflatable play equipment at our Hullbridge workshop, including panel replacements, bed and back panel stitching, anchor points, internal repairs, blower and fan maintenance, and repair materials. Pre-examination service available for £30.
-
-### [PIPA Inspections](/pipa-inspections/)
-
-Annual PIPA safety inspections by a certified PIPA Inspection Body (since 2004), following BS EN 14960. Covers bouncy castles, assault courses, slides, disco domes and more, plus non-PIPA annual inspections for pole joust, pool inflatables, gladiators and similar.
-
-### Parts & Equipment
-
-Stakes, fans, blowers, replacement parts, and second-hand equipment when available. Contact us for current stock and pricing.
-
-### [HSE Best Practice](/hse-best-practice/)
-
-Guidance on your responsibilities as an operator under HSE rules, BS EN 14960, and the annual testing process.
-
-### Service Coverage Area
-
-We serve operators throughout Essex, London, Kent, Hertfordshire, Surrey, and the broader Southeast region. For PIPA inspections we travel to council facilities, schools, and operator locations. For repairs, equipment must be delivered to our Hullbridge facility.
-
-### Get in Touch
-
-Phone: [01268 569302](tel:01268569302) · Email: [enquiries@essexinflatables.co.uk](mailto:enquiries@essexinflatables.co.uk)
-
-Or use our [contact page](/contact/) to send an enquiry.
-
-![](/images/dad3.jpg)

--- a/pages/services.md
+++ b/pages/services.md
@@ -6,7 +6,7 @@ meta_description: Comprehensive repair and PIPA inspection services for inflatab
 eleventyNavigation:
   key: Services
   order: 1
-layout: design-system-base.md
+layout: design-system-base.html
 permalink: /services/
 blocks:
   - type: hero

--- a/pages/thank-you.md
+++ b/pages/thank-you.md
@@ -2,9 +2,14 @@
 header_image: /images/bouncy-slide.jpg
 header_text: Thank You
 meta_title: Thank You
+layout: design-system-base.md
 permalink: /thank-you/
+blocks:
+  - type: hero
+    title: Thank You
+  - type: markdown
+    content: |
+      ## Thank You
+
+      Your message has been sent - we will be in touch.
 ---
-
-## Thank You
-
-Your message has been sent - we will be in touch.

--- a/pages/thank-you.md
+++ b/pages/thank-you.md
@@ -2,7 +2,7 @@
 header_image: /images/bouncy-slide.jpg
 header_text: Thank You
 meta_title: Thank You
-layout: design-system-base.md
+layout: design-system-base.html
 permalink: /thank-you/
 blocks:
   - type: hero

--- a/products/bouncy-castle-stakes.md
+++ b/products/bouncy-castle-stakes.md
@@ -6,7 +6,7 @@ header_image: /images/bouncy-slide.jpg
 header_text: Stakes and Anchor Points
 categories:
   - for-sale.md
-layout: design-system-base.md
+layout: design-system-base.html
 blocks:
   - type: hero
     title: Stakes and Anchor Points

--- a/products/bouncy-castle-stakes.md
+++ b/products/bouncy-castle-stakes.md
@@ -6,18 +6,23 @@ header_image: /images/bouncy-slide.jpg
 header_text: Stakes and Anchor Points
 categories:
   - for-sale.md
+layout: design-system-base.md
+blocks:
+  - type: hero
+    title: Stakes and Anchor Points
+  - type: markdown
+    content: |
+      ## Stakes for Securing Inflatable Equipment
+
+      We supply both new and used stakes for securing inflatable play equipment. Stakes are essential safety equipment that must be properly maintained and replaced when showing signs of wear or damage.
+
+      ### Pricing Information
+
+      Stake prices fluctuate based on current steel costs at the time of purchase. We provide quotes based on current market prices when you enquire. Both individual stakes and bulk orders are available, with discounts possible for larger quantities.
+
+      ### Availability
+
+      Stock levels vary as stakes are popular items amongst operators. We maintain supplies of standard stake sizes and can source specific requirements if needed. Please contact us to check current availability and pricing.
+
+      For quotes and current stock information, please call 01268 569302 or email enquiries@essexinflatables.co.uk.
 ---
-
-## Stakes for Securing Inflatable Equipment
-
-We supply both new and used stakes for securing inflatable play equipment. Stakes are essential safety equipment that must be properly maintained and replaced when showing signs of wear or damage.
-
-### Pricing Information
-
-Stake prices fluctuate based on current steel costs at the time of purchase. We provide quotes based on current market prices when you enquire. Both individual stakes and bulk orders are available, with discounts possible for larger quantities.
-
-### Availability
-
-Stock levels vary as stakes are popular items amongst operators. We maintain supplies of standard stake sizes and can source specific requirements if needed. Please contact us to check current availability and pricing.
-
-For quotes and current stock information, please call 01268 569302 or email enquiries@essexinflatables.co.uk.

--- a/products/spare-parts.md
+++ b/products/spare-parts.md
@@ -6,7 +6,7 @@ header_image: /images/bouncy-slide.jpg
 header_text: Parts & Equipment
 categories:
   - for-sale.md
-layout: design-system-base.md
+layout: design-system-base.html
 blocks:
   - type: hero
     title: Parts & Equipment

--- a/products/spare-parts.md
+++ b/products/spare-parts.md
@@ -6,35 +6,40 @@ header_image: /images/bouncy-slide.jpg
 header_text: Parts & Equipment
 categories:
   - for-sale.md
+layout: design-system-base.md
+blocks:
+  - type: hero
+    title: Parts & Equipment
+  - type: markdown
+    content: |
+      ## Spare Parts and Equipment for Operators
+
+      We maintain stocks of essential spare parts and equipment to keep your inflatable business operational. From replacement fans to accessories and second-hand units, we supply the components operators need to stay operational.
+
+      ### Fans and Blowers
+
+      We offer both new and reconditioned fans and blowers suitable for various inflatable sizes. Our selection includes different power ratings to match your specific equipment requirements. All electrical equipment can be PAT tested for safety compliance.
+
+      For fan repair, cleaning, and servicing, please see our [Repair Services](/repairs/) page.
+
+      ### Additional Equipment
+
+      We supply various accessories and replacement parts including:
+
+      - Extra cones for blower attachments
+      - Replacement anchor points and D-rings
+      - Safety mats and ground sheets
+      - Transport bags and storage covers
+
+      ### Second-Hand Equipment
+
+      Quality used inflatable equipment becomes available periodically through our connections with Ellis Leisure and other operators. When available, we can facilitate sales of:
+
+      - Complete inflatable units in good condition
+      - Refurbished blowers and fans
+      - Bulk lots of equipment from operators leaving the industry
+
+      Second-hand equipment availability varies greatly. Please contact us to discuss current stock or to be notified when suitable equipment becomes available.
+
+      For current stock, pricing, and availability, please contact us on 01268 569302 or email enquiries@essexinflatables.co.uk.
 ---
-
-## Spare Parts and Equipment for Operators
-
-We maintain stocks of essential spare parts and equipment to keep your inflatable business operational. From replacement fans to accessories and second-hand units, we supply the components operators need to stay operational.
-
-### Fans and Blowers
-
-We offer both new and reconditioned fans and blowers suitable for various inflatable sizes. Our selection includes different power ratings to match your specific equipment requirements. All electrical equipment can be PAT tested for safety compliance.
-
-For fan repair, cleaning, and servicing, please see our [Repair Services](/repairs/) page.
-
-### Additional Equipment
-
-We supply various accessories and replacement parts including:
-
-- Extra cones for blower attachments
-- Replacement anchor points and D-rings
-- Safety mats and ground sheets
-- Transport bags and storage covers
-
-### Second-Hand Equipment
-
-Quality used inflatable equipment becomes available periodically through our connections with Ellis Leisure and other operators. When available, we can facilitate sales of:
-
-- Complete inflatable units in good condition
-- Refurbished blowers and fans
-- Bulk lots of equipment from operators leaving the industry
-
-Second-hand equipment availability varies greatly. Please contact us to discuss current stock or to be notified when suitable equipment becomes available.
-
-For current stock, pricing, and availability, please contact us on 01268 569302 or email enquiries@essexinflatables.co.uk.


### PR DESCRIPTION
## Summary
Refactored all content pages to use a unified `design-system-base.html` layout with a block-based content structure instead of individual custom layouts. This standardizes the page architecture across the site and enables consistent styling and component reuse.

## Key Changes
- **Layout Migration**: Changed all pages from custom layouts (`base.html`, `contact.html`, `home.html`, `categories.html`, `news-archive.html`) to `design-system-base.html`
- **Block Structure**: Converted all page content to use a blocks array with `hero` and `markdown` block types:
  - `hero` blocks contain page title and optional lead text
  - `markdown` blocks contain the main page content
- **Content Preservation**: All existing content maintained exactly as-is, only restructured into the new block format
- **Frontmatter Updates**: Added `layout` and `blocks` properties to all affected pages while preserving existing metadata (meta_description, meta_title, eleventyNavigation, etc.)

## Pages Updated
- Service pages: repairs, pipa-inspections, hse-best-practices, contact, services
- Category pages: repairs, tests, for-sale
- Product pages: spare-parts, bouncy-castle-stakes
- Utility pages: home, faq, links, news, not-found, thank-you
- News article: second.md

## Implementation Details
- The hero block automatically uses the page's `title` and `lead` (from subtitle) properties
- All markdown content is indented within the block's `content` property for proper YAML formatting
- Existing redirect_from and other frontmatter properties are preserved unchanged
- This change enables future design system enhancements without modifying individual page content

https://claude.ai/code/session_01Y5gRW81scFFkuDH7cX78jv